### PR TITLE
Fix stdin string escaping issue in ReplaceStdIn function

### DIFF
--- a/util/replaceStdIn.go
+++ b/util/replaceStdIn.go
@@ -32,8 +32,13 @@ func ReplaceStdIn(input []byte) ([]byte, error) {
 
 		stdInStr := string(data)
 		stdInStr = removeControlChars(stdInStr)
-		stdInStr = strings.Replace(stdInStr, "\"", "\\\"", -1)
-		stdInStr = strings.Replace(stdInStr, "\n", "\\n", -1)
+
+		escapedStdIn, err := json.Marshal(stdInStr)
+		if err != nil {
+			return nil, fmt.Errorf("Error escaping stdin string: %v", err)
+		}
+		stdInStr = string(escapedStdIn[1 : len(escapedStdIn)-1])
+
 		result := strings.Replace(inputStr, "${STDIN}", stdInStr, -1)
 		return []byte(result), nil
 	}


### PR DESCRIPTION
This commit resolves the issue with incorrect escaping of special characters in the ReplaceStdIn function. Instead of manually escaping double quotes and new lines, we now use the json.Marshal function to properly escape the input string. This ensures that the resulting JSON is valid, even when the input contains special characters or escape sequences.