### PR TITLE
Add debug flag and refactor error handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,19 +23,19 @@ For example, the following command:
 
 reads from the YAML configuration file, processes the "translate" function, and sends an API request to an API.
 The response is then printed to stdout. For more Information about YAML Configuration, visit https://github.com/nvima/httpcli.`,
-	RunE: tplCommand,
+	RunE:          tplCommand,
+	SilenceUsage:  true,
+	SilenceErrors: true,
 }
 
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(1)
-	}
+func Execute() error {
+	return rootCmd.Execute()
 }
 
 func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.httpcli.yaml)")
+	rootCmd.PersistentFlags().Bool("debug", false, "Enable debug mode for error logging")
 }
 
 func initConfig() {

--- a/cmd/testdata/config.yaml
+++ b/cmd/testdata/config.yaml
@@ -38,3 +38,8 @@ emptyoutput:
 emptyurl:
   env:
     - "TEST_SERVER_URL"
+wrongstatuscode:
+  url: "${TEST_SERVER_URL}/nonexistentpath"
+  statuscode: 200
+  env:
+    - "TEST_SERVER_URL"

--- a/cmd/tpl_test.go
+++ b/cmd/tpl_test.go
@@ -114,7 +114,17 @@ func TestEmptyUrl(t *testing.T) {
 	rootCmd.SetOut(b)
 	rootCmd.SetArgs([]string{"emptyurl", "--config", "./testdata/config.yaml"})
 	err := rootCmd.Execute()
-	if err.Error() != util.NO_URL_ERR.Msg() {
-		t.Fatalf("expected \"%s\" got \"%s\"", util.NO_URL_ERR.Msg(), err.Error())
+	if err.Error() != util.NO_URL_ERR.Error() {
+		t.Fatalf("expected \"%s\" got \"%s\"", util.NO_URL_ERR.Error(), err.Error())
+	}
+}
+
+func TestWrongStatusCode(t *testing.T) {
+	b := bytes.NewBufferString("")
+	rootCmd.SetOut(b)
+	rootCmd.SetArgs([]string{"wrongstatuscode", "--config", "./testdata/config.yaml"})
+	err := rootCmd.Execute()
+	if err.Error() != util.INVALID_RESP_CODE.Error() {
+		t.Fatalf("expected \"%s\" got \"%s\"", util.INVALID_RESP_CODE.Error(), err.Error())
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,8 +1,14 @@
 package main
 
-import "github.com/nvima/httpcli/cmd"
+import (
+	"os"
+
+	"github.com/nvima/httpcli/cmd"
+)
 
 func main() {
-        cmd.Execute()
+	err := cmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
 }
-

--- a/util/errors.go
+++ b/util/errors.go
@@ -1,52 +1,21 @@
 package util
 
 import (
-	"fmt"
+	"errors"
 )
 
-type TplError struct {
-	msg      string
-	err      error
-}
-
-func (te TplError) Err() error {
-	return fmt.Errorf(te.msg)
-}
-
-func (te TplError) Msg() string {
-	return te.msg
-}
-
-var NO_CONFIG_FILE_ERR = TplError{
-	msg:      "No config file found",
-}
-
-var NO_FUNC_NAME_ERR = TplError{
-	msg:      "No function name provided",
-}
-var NO_FUNC_FOUND_ERR = TplError{
-	msg:      "Function not found in config",
-}
-
-var INVALID_CONFIG_ERR = TplError{
-	msg:      "Invalid config file",
-}
-
-var INVALID_RESP_CODE = TplError{
-	msg:      "Invalid response code",
-}
-var FAILED_TO_GET_DATA = TplError{
-	msg:      "Failed to get data",
-}
-var FAILED_TO_MAKE_HTTP_CALL = TplError{
-	msg:      "Failed to make http call",
-}
-var FAILED_TO_PARSE_JSON = TplError{
-	msg:      "Failed to parse JSON",
-}
-var FAILED_TO_PARSE_OUTPUT_FIELD = TplError{
-	msg:      "Failed to parse output field",
-}
-var NO_URL_ERR = TplError{
-	msg:      "No URL provided",
-}
+var NO_CONFIG_FILE_ERR = errors.New("No config file found")
+var NO_FUNC_NAME_ERR = errors.New("No function name provided")
+var NO_FUNC_FOUND_ERR = errors.New("Function not found in config")
+var INVALID_CONFIG_ERR = errors.New("Invalid config file")
+var INVALID_RESP_CODE = errors.New("Invalid response code")
+var FAILED_TO_GET_DATA = errors.New("Failed to get data")
+var FAILED_TO_MAKE_HTTP_CALL = errors.New("Failed to make http call")
+var FAILED_TO_PARSE_JSON_RESPONSE = errors.New("Failed to parse JSON Response")
+var FAILED_TO_PARSE_OUTPUT_FIELD = errors.New("Failed to parse output field")
+var NO_URL_ERR = errors.New("No URL provided")
+var MARSHAL_DATA_FAILED = errors.New("Failed to marshal data")
+var REPLACE_STDIN_FAILED = errors.New("Failed to replace stdin")
+var INIT_HTTP_POST_REQUEST_FAILED = errors.New("An error occurred while initializing the HTTP POST request. Possible causes could be an invalid URL or incorrect input parameters.")
+var SEND_HTTP_POST_REQUEST_FAILED = errors.New("An error occurred while sending the HTTP POST request. Possible causes could be network issues, server unavailability, or issues with the request payload.")
+var READ_RESPONSE_BODY_FAILED = errors.New("Failed to read the response body")

--- a/util/handleError.go
+++ b/util/handleError.go
@@ -1,15 +1,15 @@
 package util
 
 import (
-	// "fmt"
+	"fmt"
 
 	"github.com/spf13/cobra"
 )
 
-func HandleError(cmd *cobra.Command, err error, tplError TplError) error {
-	//TODO:: Add Error Logging with Stacktraces
-	// fmt.Println(err)
-
-	// fmt.Fprintf(cmd.OutOrStdout(), tplError.msg)
-	return err
+func HandleError(cmd *cobra.Command, err error, tplError error) error {
+	debug, _ := cmd.Flags().GetBool("debug")
+	if debug {
+		fmt.Printf("Debug: %v\n", err)
+	}
+	return tplError
 }


### PR DESCRIPTION
Introduce a new --debug flag to provide more detailed error messages Change the program to return exit code 1 when an error occurs Refactor error handling for better readability and maintainability Update test cases to reflect changes